### PR TITLE
Version Number to match

### DIFF
--- a/Reso360Spout/Main.cs
+++ b/Reso360Spout/Main.cs
@@ -218,7 +218,7 @@ namespace Reso360Spout
         // --- Properties (Override) ----------------------------------------
         public override string Name => "Reso360Spout";
         public override string Author => "kka429";
-        public override string Version => "0.0.2";
+        public override string Version => "0.0.6";
         public override string Link => "https://github.com/rassi0429/Reso360Spout";
 
         // --- Public Fields ------------------------------------------------


### PR DESCRIPTION
Updated this so it matches your release number


![image](https://github.com/user-attachments/assets/29247331-55c1-42ae-8760-2e6af866c95a)

![image](https://github.com/user-attachments/assets/0ff53dae-9554-449b-95c1-cb29d7f83934)

Wanted to make sure these match...